### PR TITLE
Add basic block registration for 1.20.1 port

### DIFF
--- a/docs/PORT_TO_1_20_1.md
+++ b/docs/PORT_TO_1_20_1.md
@@ -21,4 +21,5 @@ This document tracks initial work on bringing the classic mod up to date with th
 This file will expand as the port progresses.
 
 ## Progress
-- Basic mod entry point and item DeferredRegister created. A sample item `ancient_fruit` now loads in game for verification.
+- Basic mod entry point and item `DeferredRegister` created. A sample item `ancient_fruit` now loads in game for verification.
+- Block registration added with a placeholder block `test_block`.

--- a/src/main/java/com/lycanitesmobs/newversion/LycanitesMobsForge.java
+++ b/src/main/java/com/lycanitesmobs/newversion/LycanitesMobsForge.java
@@ -4,6 +4,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import com.lycanitesmobs.newversion.ModItems;
+import com.lycanitesmobs.newversion.ModBlocks;
 
 /**
  * Entry point for the Forge 1.20.1 port.
@@ -16,6 +17,7 @@ public class LycanitesMobsForge {
     public LycanitesMobsForge() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         ModItems.ITEMS.register(modEventBus);
-        // TODO: Register blocks and entities using DeferredRegister
+        ModBlocks.BLOCKS.register(modEventBus);
+        // TODO: Register entities using DeferredRegister
     }
 }

--- a/src/main/java/com/lycanitesmobs/newversion/ModBlocks.java
+++ b/src/main/java/com/lycanitesmobs/newversion/ModBlocks.java
@@ -1,0 +1,22 @@
+package com.lycanitesmobs.newversion;
+
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+/**
+ * Example block registry for the 1.20.1 Forge port.
+ */
+public class ModBlocks {
+    public static final DeferredRegister<Block> BLOCKS =
+            DeferredRegister.create(ForgeRegistries.BLOCKS, LycanitesMobsForge.MODID);
+
+    public static final RegistryObject<Block> TEST_BLOCK = BLOCKS.register(
+            "test_block",
+            () -> new Block(BlockBehaviour.Properties.copy(Blocks.STONE))
+    );
+}


### PR DESCRIPTION
## Summary
- register a new `test_block` via `ModBlocks`
- hook block registration into the Forge entry point
- update porting progress docs

## Testing
- `./gradlew build` *(fails: Could not determine java version)*

------
https://chatgpt.com/codex/tasks/task_e_688c3fb2afbc83278104031d797261d1